### PR TITLE
Lockerror

### DIFF
--- a/sensors/hy1361_runner.py
+++ b/sensors/hy1361_runner.py
@@ -5,6 +5,7 @@ import mqtt_helper as mh
 import time
 import sqlite3
 import logging
+import sys
 
 logging.basicConfig(level=logging.WARNING)
 

--- a/sensors/hy1361_runner.py
+++ b/sensors/hy1361_runner.py
@@ -7,7 +7,7 @@ import sqlite3
 import logging
 import sys
 
-logging.basicConfig(level=logging.WARNING)
+logging.basicConfig(format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.WARNING)
 
 # Device information
 LOCATION = 2

--- a/sensors/sds011_runner.py
+++ b/sensors/sds011_runner.py
@@ -7,8 +7,7 @@ import logging
 import sqlite3
 import sys
 
-
-logging.basicConfig(level=logging.WARNING)
+logging.basicConfig(format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.WARNING)
 
 
 def write_to_db(measurement, table):
@@ -59,6 +58,15 @@ if __name__ == '__main__':
             data = str([data])
             mh.send(device_id, 'event', data, 'SDS011')
             write_to_db(measurement, "measurements")
-    except:
+    except KeyboardInterrupt:
         sds.__del__()
-        logging.warning('closed')
+        logging.warning('keyboard interrupt: gracefully exited')
+    except Exception:
+        err = sys.exc_info()
+        err_message = traceback.format_exception(*err)
+        err_str = '<br>'.join(err_message)
+        err_str = err_str.replace('\n', '')
+        issue = "Issue writing to database: <br> {}".format(err_str)
+        sds.__del__()
+        logging.warning('New error. Executing graceful shutdown. Details as follows:')
+        logging.warning(issue)

--- a/sensors/sds011_runner.py
+++ b/sensors/sds011_runner.py
@@ -42,6 +42,8 @@ if __name__ == '__main__':
     db3path = "measurements.db3"
     while True:
         try:
+            logging.debug('started another loop')
+            
             # set up db connection
             conn = sqlite3.connect(db3path)
             logging.info('connected to database')


### PR DESCRIPTION
Code was running well except that when trying to write to the local database, the following error would sometimes arise:

```
sqlite3.OperationalError: database is locked
```
This appears to be a common issue when multiple parties are writing to the same SQLite database. Due to the structure of the code, the whole program would shut down at this point result in a period of no data until I restarted the program. I decided there were a few approaches to this:

1. This error shouldn't cause the whole program to crash. Better to lose, at worst, one data point forever but continue recording than to have a loss of hours - days of data.
2. Explore if it is possible to change the settings of the SQLite database to see if it could be made more friendly to concurrent use.
3. Explore using another database which would be more friendly to concurrent use.

I decided to start with one as it was clear the program could use some better error handling. This push is the solution to part 1.

For possibility 2, it looks like it should be possible by implementing write ahead logging (see [here](https://sqlite.org/wal.html)). This should eliminate the need to explore option 3.

I am not implementing option 2 at this time because I would like the error to come up again naturally and confirm that the code handles it as expected.