### PR TITLE
moving to use write ahead logging.

### DIFF
--- a/sensors/hy1361_runner.py
+++ b/sensors/hy1361_runner.py
@@ -21,6 +21,8 @@ WEIGHTS = ["A", "C"]
 
 def write_to_db(measurement, conn, table):
     c = conn.cursor()
+    # use write ahead logging
+    c.execute('PRAGMA journal_mode=wal')
     c.execute("insert into {0} (db, range, weight, speed, location, measurement_ts) values (?,?,?,?,?,?)".format(table), measurement)
     conn.commit()
     conn.close()

--- a/sensors/sds011_runner.py
+++ b/sensors/sds011_runner.py
@@ -13,6 +13,8 @@ logging.basicConfig(format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S
 
 def write_to_db(measurement, conn, table):
     c = conn.cursor()
+    # use write ahead logging
+    c.execute('PRAGMA journal_mode=wal')
     linedata = [measurement.get(x) for x in ["timestamp","pm2.5","pm10","devid"]]
     c.execute("insert into {0} (timestamp,pm2_5,pm10,devid) values (?,?,?,?)".format(table),linedata)
     conn.commit()


### PR DESCRIPTION
This ties to [this issue](https://github.com/fritzel56/rpi-sensors/issues/4) and is a follow on to [this PR](https://github.com/fritzel56/rpi-sensors/pull/5). While the previous PR mitigated the impact of the `database is locked` error, some (very small) amount of data would be lost to the local database. No data was being lost to BigQuery but in the event of a wifi outage, this could still have resulted in (very small) amounts of lost data.

This PR moves the python code over to use sqlite's write ahead logging (wal) mode which should actually resolve the issue. Per the doc page [here](https://sqlite.org/wal.html), WAL should `provides more concurrency`. Pupli had provided an example of how to implement WAL in python [here](https://pupli.net/2020/09/sqlite-wal-mode-in-python/).

Will follow up in a few months to ensure no new instances of the database is locked` error have occurred. If that pans out, will the close the issue.